### PR TITLE
Remove "quick listener check" and don't mute connection

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -45,18 +45,6 @@ func newConn(conf connConfig, muted bool) (*conn, error) {
 	if err != nil {
 		return c, err
 	}
-	// When using UDP do a quick check to see if something is listening on the
-	// given port to return an error as soon as possible.
-	if c.network[:3] == "udp" {
-		for i := 0; i < 2; i++ {
-			_, err = c.w.Write(nil)
-			if err != nil {
-				_ = c.w.Close()
-				c.w = nil
-				return c, err
-			}
-		}
-	}
 
 	// To prevent a buffer overflow add some capacity to the buffer to allow for
 	// an additional metric.

--- a/statsd_test.go
+++ b/statsd_test.go
@@ -336,10 +336,7 @@ func TestDialError(t *testing.T) {
 	}
 	defer func() { dialTimeout = net.DialTimeout }()
 
-	c, err := New()
-	if c == nil || !c.muted {
-		t.Error("New() did not return a muted client")
-	}
+	_, err := New()
 	if err == nil {
 		t.Error("New() did not return an error")
 	}
@@ -364,11 +361,11 @@ func TestUDPNotListening(t *testing.T) {
 	defer func() { dialTimeout = net.DialTimeout }()
 
 	c, err := New()
-	if c == nil || !c.muted {
-		t.Error("New() did not return a muted client")
+	if c.muted {
+		t.Error("client should not mute when attempting to connect to a non-listening port")
 	}
-	if err == nil {
-		t.Error("New should return an error")
+	if err != nil {
+		t.Error("attempting to connect to a non-listening port should not return an error")
 	}
 }
 


### PR DESCRIPTION
This commit removes "quick listener check" which mutes connection and returns an error
when the listener isn't available at the time of initialization.
